### PR TITLE
Feat: Implementasi Registrasi User

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,11 +5,13 @@
     "": {
       "name": "contohai",
       "dependencies": {
+        "bcryptjs": "^3.0.3",
         "drizzle-orm": "^0.45.2",
         "elysia": "^1.4.28",
-        "mysql2": "^3.22.2",
+        "postgres": "^3.4.9",
       },
       "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
         "@types/bun": "^1.3.13",
         "drizzle-kit": "^0.31.10",
       },
@@ -85,11 +87,15 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
+    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
+
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
+
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
@@ -140,6 +146,8 @@
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,8 +3,13 @@ import { defineConfig } from "drizzle-kit";
 export default defineConfig({
   schema: "./src/db/schema.ts",
   out: "./drizzle",
-  dialect: "mysql",
+  dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    host: process.env.DB_HOST || "localhost",
+    port: Number(process.env.DB_PORT) || 5432,
+    user: process.env.DB_USER || "root",
+    password: process.env.DB_PASSWORD || "",
+    database: process.env.DB_NAME || "contoh_ai",
+    ssl: false,
   },
 });

--- a/drizzle/0000_curvy_human_robot.sql
+++ b/drizzle/0000_curvy_human_robot.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "users" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"password" varchar(255) NOT NULL,
+	"create_at" timestamp DEFAULT now(),
+	CONSTRAINT "users_email_unique" UNIQUE("email")
+);

--- a/drizzle/0000_worthless_captain_flint.sql
+++ b/drizzle/0000_worthless_captain_flint.sql
@@ -1,8 +1,0 @@
-CREATE TABLE `users` (
-	`id` serial AUTO_INCREMENT NOT NULL,
-	`name` varchar(255) NOT NULL,
-	`email` varchar(255) NOT NULL,
-	`created_at` timestamp DEFAULT (now()),
-	CONSTRAINT `users_id` PRIMARY KEY(`id`),
-	CONSTRAINT `users_email_unique` UNIQUE(`email`)
-);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,71 +1,71 @@
 {
-  "version": "5",
-  "dialect": "mysql",
-  "id": "c6d3ef52-84e8-401b-94fe-6d38ddb16856",
+  "id": "b0bb20d7-0939-46cb-bbcd-363352ed5e61",
   "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
   "tables": {
-    "users": {
+    "public.users": {
       "name": "users",
+      "schema": "",
       "columns": {
         "id": {
           "name": "id",
           "type": "serial",
-          "primaryKey": false,
-          "notNull": true,
-          "autoincrement": true
+          "primaryKey": true,
+          "notNull": true
         },
         "name": {
           "name": "name",
           "type": "varchar(255)",
           "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
+          "notNull": true
         },
         "email": {
           "name": "email",
           "type": "varchar(255)",
           "primaryKey": false,
-          "notNull": true,
-          "autoincrement": false
+          "notNull": true
         },
-        "created_at": {
-          "name": "created_at",
+        "password": {
+          "name": "password",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "create_at": {
+          "name": "create_at",
           "type": "timestamp",
           "primaryKey": false,
           "notNull": false,
-          "autoincrement": false,
-          "default": "(now())"
+          "default": "now()"
         }
       },
       "indexes": {},
       "foreignKeys": {},
-      "compositePrimaryKeys": {
-        "users_id": {
-          "name": "users_id",
-          "columns": [
-            "id"
-          ]
-        }
-      },
+      "compositePrimaryKeys": {},
       "uniqueConstraints": {
         "users_email_unique": {
           "name": "users_email_unique",
+          "nullsNotDistinct": false,
           "columns": [
             "email"
           ]
         }
       },
-      "checkConstraint": {}
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
     }
   },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
   "views": {},
   "_meta": {
+    "columns": {},
     "schemas": {},
-    "tables": {},
-    "columns": {}
-  },
-  "internal": {
-    "tables": {},
-    "indexes": {}
+    "tables": {}
   }
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,12 +1,12 @@
 {
   "version": "7",
-  "dialect": "mysql",
+  "dialect": "postgresql",
   "entries": [
     {
       "idx": 0,
-      "version": "5",
-      "when": 1776932953041,
-      "tag": "0000_worthless_captain_flint",
+      "version": "7",
+      "when": 1776938619817,
+      "tag": "0000_curvy_human_robot",
       "breakpoints": true
     }
   ]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "private": true,
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@types/bun": "^1.3.13",
     "drizzle-kit": "^0.31.10"
   },
@@ -11,8 +12,9 @@
     "typescript": "^5"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.3",
     "drizzle-orm": "^0.45.2",
     "elysia": "^1.4.28",
-    "mysql2": "^3.22.2"
+    "postgres": "^3.4.9"
   }
 }

--- a/prompt.txt
+++ b/prompt.txt
@@ -1,0 +1,47 @@
+Buatkan issue.md yang berisi perencanaan untuk nanti di implementasikan oleh junior progammer atau ai model yang lebih murah.
+
+Isi dari planning nya adalah sebagai berikut :
+
+buat table user:
+id integer auto increment
+name varchar 255 not null
+email varchar 255 not null
+password varchar 255 not null(password merupakan
+hash dari bcrypt)
+create_at timestamp default current_timestamp
+
+Buatkan API untuk regristasi user baru
+
+Endpoint : POST /api/users
+
+Request body :
+{
+    "name": "David",
+    "email": "david@localhost",
+    "password": "rahasia"
+}
+
+Response body (Succes) :
+{
+    "data": "Ok"
+}
+
+Response body (Error)\
+{
+    "error": "Email sudah terdaftar"
+}
+
+Struktur folder di dalam src
+- routes : ini berisi routing elysia js
+- services : ini berisi logic bisnis aplikasi
+
+Struktur file
+- routes : menggunakan format misal users-route.ts
+- services : menggunakan format misal users-service.ts
+
+Jelaskan step tahapan-tahapan yang harus di lakukan untuk 
+mengimplementasikan fitur ini, anggap nanti yang mengimplementasikan 
+adalah junior progammer atau model AI yang lebih murah.
+
+Pastikan setiap step menggunakan markdown yang mudah di baca.
+

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,13 @@
-import { drizzle } from "drizzle-orm/mysql2";
-import mysql from "mysql2/promise";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
 import * as schema from "./schema";
 
-const connection = await mysql.createConnection(process.env.DATABASE_URL!);
-export const db = drizzle(connection, { schema, mode: "default" });
+const queryClient = postgres({
+  host: process.env.DB_HOST || "localhost",
+  port: Number(process.env.DB_PORT) || 5432,
+  user: process.env.DB_USER || "root",
+  password: process.env.DB_PASSWORD || "",
+  database: process.env.DB_NAME || "contoh_ai",
+});
+
+export const db = drizzle(queryClient, { schema });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,8 +1,9 @@
-import { mysqlTable, serial, varchar, timestamp } from "drizzle-orm/mysql-core";
+import { pgTable, serial, varchar, timestamp } from "drizzle-orm/pg-core";
 
-export const users = mysqlTable("users", {
+export const users = pgTable("users", {
   id: serial("id").primaryKey(),
   name: varchar("name", { length: 255 }).notNull(),
   email: varchar("email", { length: 255 }).notNull().unique(),
-  createdAt: timestamp("created_at").defaultNow(),
+  password: varchar("password", { length: 255 }).notNull(),
+  create_at: timestamp("create_at").defaultNow(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,9 @@
 import { Elysia } from "elysia";
-import { db } from "./db";
-import { users } from "./db/schema";
+import { usersRoute } from "./routes/users-route";
 
 const app = new Elysia()
   .get("/", () => "Hello World")
-  .get("/users", async () => {
-    return await db.select().from(users);
-  })
+  .use(usersRoute)
   .listen(3000);
 
 console.log(

--- a/src/routes/users-route.ts
+++ b/src/routes/users-route.ts
@@ -1,0 +1,22 @@
+import { Elysia, t } from "elysia";
+import { registerUser } from "../services/users-service";
+
+export const usersRoute = new Elysia({ prefix: "/api/users" }).post(
+  "/",
+  async ({ body, set }) => {
+    try {
+      await registerUser(body);
+      return { data: "Ok" };
+    } catch (error: any) {
+      set.status = 400;
+      return { error: error.message };
+    }
+  },
+  {
+    body: t.Object({
+      name: t.String(),
+      email: t.String(),
+      password: t.String(),
+    }),
+  }
+);

--- a/src/services/users-service.ts
+++ b/src/services/users-service.ts
@@ -1,0 +1,31 @@
+import { db } from "../db";
+import { users } from "../db/schema";
+import { eq } from "drizzle-orm";
+import bcrypt from "bcryptjs";
+
+export const registerUser = async (payload: any) => {
+  const { name, email, password } = payload;
+
+  // 1. Check if email already exists
+  const existingUser = await db
+    .select()
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  if (existingUser.length > 0) {
+    throw new Error("Email sudah terdaftar");
+  }
+
+  // 2. Hash password
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  // 3. Insert user
+  await db.insert(users).values({
+    name,
+    email,
+    password: hashedPassword,
+  });
+
+  return { success: true };
+};


### PR DESCRIPTION
Implementasi fitur registrasi user baru sesuai spesifikasi di Issue #4.

## Perubahan
- Menambahkan kolom `password` dan `create_at` ke skema tabel `users`
- Migrasi database ke PostgreSQL dengan Drizzle ORM
- Membuat `users-service.ts` dengan logika registrasi (cek email duplikat + bcrypt hashing)
- Membuat `users-route.ts` dengan endpoint `POST /api/users`
- Mendaftarkan route ke aplikasi utama di `index.ts`

## Endpoint
**POST /api/users**
- Request: `{ name, email, password }`
- Success: `{ "data": "Ok" }`
- Error: `{ "error": "Email sudah terdaftar" }`

Closes #4
